### PR TITLE
Remove Android-specific code and use the CMake crate for building

### DIFF
--- a/energymon-builder/Cargo.toml
+++ b/energymon-builder/Cargo.toml
@@ -13,4 +13,5 @@ name = "energymon_builder"
 path = "lib.rs"
 
 [dependencies]
+cmake = "0.1"
 pkg-config = "0.3.2"


### PR DESCRIPTION
Related issues: libheartbeats/heartbeats-simple-sys#17, servo/servo#13154

I've removed the Android-specific toolchain code, and changed the build to use the CMake crate's builder pattern. I had to change the `build` output path too, as this now builds to `$OUT_DIR/build`, not `$OUT_DIR/_build`.

At the moment we have some include problems on the Servo side (cc @larsbergstrom), but I'm leaving this PR here for review until then.
